### PR TITLE
fix: unsupported "createObjectURL" function is replaced

### DIFF
--- a/src/components/vedioCall.js
+++ b/src/components/vedioCall.js
@@ -22,7 +22,7 @@ class VedioCall extends Component {
 
   handleVideo= (stream)=> {
     // Update the state, triggering the component to re-render with the correct stream
-    this.refs.video.src = window.URL.createObjectURL(stream);
+    this.refs.video.srcObject = stream;
   };
 
   videoError= ()=> {


### PR DESCRIPTION
createObjectURL is an older method, and replaced with MediaStream directly. Here is a quote from mozilla docs ([link](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/srcObject))

> Older versions of the Media Source specification required using createObjectURL() to create an object URL then setting src to that URL. Now you can just set srcObject to the MediaStream directly.